### PR TITLE
Add profiles to memberships

### DIFF
--- a/app/jobs/decorate_professional_job.rb
+++ b/app/jobs/decorate_professional_job.rb
@@ -1,11 +1,13 @@
 class DecorateProfessionalJob < ApplicationJob
   queue_as :default
 
-  def perform(model)
-    # TODO: What should this object be called?
-    # TODO: decorate method encapsulates mutations of this object.
-    # data = Medix::Registry.find(model.identifier)
-    # model.decorate(data)
-    Medix::Registry.find(model.identifier)
+  def perform(profile)
+    data = Medix::Registry.find(profile.identifier)
+    profile.update(
+      title: data.title,
+      approved: data.approved?,
+      specializations: data.specializations,
+      additional_expertise: data.additional_expertise
+    )
   end
 end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -1,0 +1,3 @@
+class Profile < ApplicationRecord
+  has_many :memberships, foreign_key: :current_profile_id, dependent: :nullify, inverse_of: :current_profile
+end

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -1,0 +1,15 @@
+class Role
+  class << self
+    def admin
+      "admin"
+    end
+
+    def physician
+      "physician"
+    end
+
+    def patient
+      "patient"
+    end
+  end
+end

--- a/config/models/roles.yml
+++ b/config/models/roles.yml
@@ -10,10 +10,10 @@ editor:
 
 admin:
   includes:
-    - editor
+    - physician
   manageable_roles:
     - admin
-    - editor
+    - physician
   models:
     Clinic: manage
     Membership: manage

--- a/db/migrate/20220408055124_create_memberships.rb
+++ b/db/migrate/20220408055124_create_memberships.rb
@@ -7,6 +7,7 @@ class CreateMemberships < ActiveRecord::Migration[7.0]
       t.string :user_last_name
       t.string :user_profile_photo_id
       t.string :user_email
+      t.integer :current_profile_id
       t.jsonb :role_ids, array: true, default: []
 
       t.timestamps

--- a/db/migrate/20220409083830_create_profiles.rb
+++ b/db/migrate/20220409083830_create_profiles.rb
@@ -1,0 +1,13 @@
+class CreateProfiles < ActiveRecord::Migration[7.0]
+  def change
+    create_table :profiles do |t|
+      t.string :title
+      t.string :identifier
+      t.boolean :approved
+      t.jsonb :specializations, default: []
+      t.jsonb :additional_expertise, default: []
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_04_08_055124) do
+ActiveRecord::Schema[7.0].define(version: 2022_04_09_083830) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -30,11 +30,22 @@ ActiveRecord::Schema[7.0].define(version: 2022_04_08_055124) do
     t.string "user_last_name"
     t.string "user_profile_photo_id"
     t.string "user_email"
+    t.integer "current_profile_id"
     t.jsonb "role_ids", default: [], array: true
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["clinic_id"], name: "index_memberships_on_clinic_id"
     t.index ["user_id"], name: "index_memberships_on_user_id"
+  end
+
+  create_table "profiles", force: :cascade do |t|
+    t.string "title"
+    t.string "identifier"
+    t.boolean "approved"
+    t.jsonb "specializations", default: []
+    t.jsonb "additional_expertise", default: []
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "users", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,10 +6,6 @@ johns = Clinic.create(
   name: "Johns Hopkins Hospital", slug: "johns-hopkins-hospital",
   time_zone: "Eastern Time (US & Canada)", locale: "en"
 )
-mayo = Clinic.create(
-  name: "Mayo Clinic", slug: "mayo-clinic",
-  time_zone: "Eastern Time (US & Canada)", locale: "en"
-)
 
 ucla_admin = User.create(
   email: "ucla@example.com", first_name: "Admin", last_name: "Ucla",
@@ -17,17 +13,38 @@ ucla_admin = User.create(
 )
 johns_admin = User.create(
   email: "johns@example.com", first_name: "Admin", last_name: "Johns",
-  current_clinic: mayo, password: "password", password_confirmation: "password"
+  current_clinic: johns, password: "password", password_confirmation: "password"
 )
-mayo_admin = User.create(
-  email: "mayo@example.com", first_name: "Admin", last_name: "Mayo",
-  current_clinic: mayo, password: "password", password_confirmation: "password"
+
+ucla_physician = User.create(
+  email: "ucla_physician@example.com", first_name: "Doctor", last_name: "Dread",
+  current_clinic: ucla, password: "password", password_confirmation: "password"
+)
+johns_physician = User.create(
+  email: "johns_physician@example.com", first_name: "Doctor", last_name: "Doom",
+  current_clinic: johns, password: "password", password_confirmation: "password"
+)
+
+physician_profile = Profile.create(
+  title: "Physician",
+  identifier: "123456789",
+  approved: true,
+  specializations: [{name: "Proctology", period: "2020-10-20..2065-06-17"}],
+  additional_expertise: [{name: "Sick leave certifications", period: "2020-10-20..2065-06-17"}]
+)
+dentist_profile = Profile.create(
+  title: "Dentist",
+  identifier: "987654321",
+  approved: true,
+  specializations: [{name: "Orthodontist", period: "2020-10-20..2065-06-17"}],
+  additional_expertise: []
 )
 
 Membership.create(
   [
-    {user: ucla_admin, clinic: ucla, role_ids: ["admin"]},
-    {user: johns_admin, clinic: johns, role_ids: ["admin"]},
-    {user: mayo_admin, clinic: mayo, role_ids: ["admin"]}
+    {user: ucla_admin, clinic: ucla, role_ids: [Role.admin]},
+    {user: ucla_physician, clinic: ucla, role_ids: [Role.physician], current_profile: physician_profile},
+    {user: johns_admin, clinic: johns, role_ids: [Role.admin]},
+    {user: johns_physician, clinic: johns, role_ids: [Role.physician], current_profile: dentist_profile}
   ]
 )

--- a/lib/medix/registry.rb
+++ b/lib/medix/registry.rb
@@ -9,7 +9,7 @@ module Medix
     :title,
     :approved?,
     :specializations,
-    :qualifications
+    :additional_expertise
   )
 
   class Registry
@@ -33,8 +33,8 @@ module Medix
         service.deceased_date,
         title,
         professional_data.approved?,
-        professional_data.specials.map(&:name),
-        professional_data.additional_expertise.map(&:name)
+        professional_data.specials,
+        professional_data.additional_expertise
       )
     end
 

--- a/spec/factories/profiles.rb
+++ b/spec/factories/profiles.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :profile do
+    title { "Physician" }
+    identifier { SecureRandom.base36 }
+    approved { true }
+    specializations { [{name: "Proctology", period: "2020-10-20..2065-06-17"}] }
+    additional_expertise { [{name: "Sick leave certifications", period: "2020-10-20..2065-06-17"}] }
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -3,6 +3,8 @@ FactoryBot.define do
     sequence(:email) { |n| "generic-user-#{n}@example.com" }
     password { "08h4f78hrc0ohw9f8heso" }
     password_confirmation { "08h4f78hrc0ohw9f8heso" }
+    first_name { Faker::Name.first_name }
+    last_name { Faker::Name.last_name }
     sign_in_count { 1 }
     current_sign_in_at { Time.zone.now }
     last_sign_in_at { 1.day.ago }

--- a/spec/jobs/decorate_professional_job_spec.rb
+++ b/spec/jobs/decorate_professional_job_spec.rb
@@ -1,10 +1,23 @@
 require "rails_helper"
 
 RSpec.describe DecorateProfessionalJob, type: :job do
-  let(:model) { OpenStruct.new(name: "John Doe", identifier: 1234567) }
+  let(:model) { create(:profile) }
+  let(:payload) do
+    OpenStruct.new(
+      title: "Physician",
+      identifier: model.identifier,
+      approved: false,
+      specializations: [{name: "Proctology"}]
+    )
+  end
 
-  it "fetches data" do
-    allow(Medix::Registry).to receive(:find).with(1234567).and_return(model)
-    expect(described_class.perform_now(model)).to eq model
+  before do
+    allow(Medix::Registry).to receive(:find).with(model.identifier).and_return(payload)
+  end
+
+  it "fetches data" do # rubocop:disable RSpec/MultipleExpectations
+    described_class.perform_now(model)
+    expect(model.title).to eq(payload.title)
+    expect(model.approved).to be_falsey
   end
 end

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+
+RSpec.describe Profile, type: :model do
+  describe "approved?" do
+    it "returns true if approved is true" do
+      profile = build(:profile, approved: true)
+      expect(profile).to be_approved
+    end
+
+    it "returns false if approved is false" do
+      profile = build(:profile, approved: false)
+      expect(profile).not_to be_approved
+    end
+  end
+end


### PR DESCRIPTION
### Background

Overloading a user model with a bunch of domain specific data can undesirable, better if this belongs in a separate profile model. Now, how are users and profiles related? `Profile.belongs_to :user` and `User.has_many_profiles`?
What is a physician, being extremely busy, wants to delegate the task of keeping their profile up-to-date? Wouldn't they have to share their credentials with an assistant, maybe not ideal.
What if instead, a user has memberships to clinics and other users also have memberships but are not physicians but admins for the clinic?
Such an admin could create a membership for a physician for their clinic and invite that physician to join. In that same context, the created membership for the physician would have a role pf physician and a profile would be created for that membership using data from the health registry.

#### Proposal
This PR tries the above approach.
- a Membership belongs to a user and a clinic
- Membership can have a current_profile
- User has a membership to a clinic and can choose to set current_clinic to their present position, as in I work here now
- Clinics can find memberships based on membership roles, e.g. admins, physicians and patients and get users and the current profile